### PR TITLE
Fix potential Serilog load error, enable debug logging into msbuild

### DIFF
--- a/NetcodePatcher.MSBuild.Tasks/NetcodePatchTask.cs
+++ b/NetcodePatcher.MSBuild.Tasks/NetcodePatchTask.cs
@@ -43,6 +43,12 @@ public class NetcodePatchTask : Task
             .InformationalVersion;
         Serilog.Log.Information("Initializing NetcodePatcher v{Version:l}", toolVersion);
 
+        if (Patch.Length < 1)
+        {
+            Serilog.Log.Information("No targets specified for Netcode patching. NetcodePatcher done.");
+            return true;
+        }
+
         var noOverwrite = false;
         if (!string.IsNullOrEmpty(NoOverwrite))
         {

--- a/NetcodePatcher.MSBuild.Tasks/NetcodePatchTask.cs
+++ b/NetcodePatcher.MSBuild.Tasks/NetcodePatchTask.cs
@@ -34,7 +34,7 @@ public class NetcodePatchTask : Task
     public override bool Execute()
     {
         Serilog.Log.Logger = new LoggerConfiguration()
-            .MinimumLevel.Information()
+            .MinimumLevel.Debug()
             .WriteTo.MSBuildTask(this)
             .CreateLogger();
 

--- a/NetcodePatcher.MSBuild.Tasks/NetcodePatchTask.cs
+++ b/NetcodePatcher.MSBuild.Tasks/NetcodePatchTask.cs
@@ -99,6 +99,7 @@ public class NetcodePatchTask : Task
                 outputPath = Path.Combine(outputPath, noOverwrite ? $"{Path.GetFileNameWithoutExtension(pluginAssembly.Name)}_patched{Path.GetExtension(pluginAssembly.Name)}" : pluginAssembly.Name);
             }
 
+            Serilog.Log.Information("Processing : {input}", inputPath);
             patchMethod.Invoke(null, [inputPath, outputPath, ReferenceAssemblyPaths.Select(info => info.ItemSpec).ToArray()]);
         }
 

--- a/NetcodePatcher.Tools.Common/PatcherLoadContext.cs
+++ b/NetcodePatcher.Tools.Common/PatcherLoadContext.cs
@@ -36,7 +36,7 @@ class PatcherLoadContext : AssemblyLoadContext
                 return Default.LoadFromAssemblyName(assemblyName);
             }
             Log.Debug("Shared Dependency {SharedName} loading from {Directory}", assemblyName, sharedPath);
-            return LoadFromAssemblyPath(sharedPath);
+            return Default.LoadFromAssemblyPath(sharedPath);
         }
 
         string? assemblyPath = ResolveAssemblyToPath(assemblyName);

--- a/NetcodePatcher.Tools.Common/PatcherLoadContext.cs
+++ b/NetcodePatcher.Tools.Common/PatcherLoadContext.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
+using Serilog;
 
 namespace NetcodePatcher.Tools.Common;
 
@@ -27,7 +28,19 @@ class PatcherLoadContext : AssemblyLoadContext
         if (assemblyName.Name is null) return null;
 
         if (SharedDependencyAssemblyNames.Contains(assemblyName.Name))
-            return Default.LoadFromAssemblyName(assemblyName);
+        {
+            string? sharedPath = ResolveAssemblyToPath(assemblyName);
+            if (sharedPath is null)
+            {
+                Log.Debug("Shared dependency {SharedName} not found in {CommonDir} or {SharedDir}, trying to load from system", assemblyName, _configuration.PatcherCommonAssemblyDir, _configuration.PatcherNetcodeSpecificAssemblyDir);
+                return Default.LoadFromAssemblyName(assemblyName);
+            }
+            else
+            {
+                Log.Debug("Shared Dependency {SharedName} loading from {Directory}", assemblyName, sharedPath);
+                return LoadFromAssemblyPath(sharedPath);
+            }
+        }
 
         string? assemblyPath = ResolveAssemblyToPath(assemblyName);
         if (assemblyPath is null) return null;

--- a/NetcodePatcher.Tools.Common/PatcherLoadContext.cs
+++ b/NetcodePatcher.Tools.Common/PatcherLoadContext.cs
@@ -35,11 +35,8 @@ class PatcherLoadContext : AssemblyLoadContext
                 Log.Debug("Shared dependency {SharedName} not found in {CommonDir} or {SharedDir}, trying to load from system", assemblyName, _configuration.PatcherCommonAssemblyDir, _configuration.PatcherNetcodeSpecificAssemblyDir);
                 return Default.LoadFromAssemblyName(assemblyName);
             }
-            else
-            {
-                Log.Debug("Shared Dependency {SharedName} loading from {Directory}", assemblyName, sharedPath);
-                return LoadFromAssemblyPath(sharedPath);
-            }
+            Log.Debug("Shared Dependency {SharedName} loading from {Directory}", assemblyName, sharedPath);
+            return LoadFromAssemblyPath(sharedPath);
         }
 
         string? assemblyPath = ResolveAssemblyToPath(assemblyName);


### PR DESCRIPTION
As is, `Default.LoadFromAssemblyName` may fail to load the Serilog dependency when using the MSBuild SDK, leading to exceptions like:

```
Sdk.targets(6,5): error : [15:53:41 FTL] Netcode patching failed! 
Sdk.targets(6,5): error : System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. 
Sdk.targets(6,5): error :    at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr) 
Sdk.targets(6,5): error :    at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture) 
Sdk.targets(6,5): error :    at NetcodePatcher.MSBuild.NetcodePatchTask.<>c__DisplayClass32_0.<Execute>g__RunPatch|0(ITaskItem patchSpecifier) in /home/runner/work/UnityNetcodePatcher/UnityNetcodePatcher/NetcodePatcher.MSBuild.Tasks/NetcodePatchTask.cs:line 96 
Sdk.targets(6,5): error :    at NetcodePatcher.MSBuild.NetcodePatchTask.Execute() in /home/runner/work/UnityNetcodePatcher/UnityNetcodePatcher/NetcodePatcher.MSBuild.Tasks/NetcodePatchTask.cs:line 105 
Sdk.targets(6,5): error : Caused by: System.IO.FileNotFoundException: Could not load file or assembly 'Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10'. The system cannot find the file specified. 
Sdk.targets(6,5): error :  
Sdk.targets(6,5): error :    at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor) 
Sdk.targets(6,5): error :    at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr) 
Sdk.targets(6,5): error : Caused by: System.IO.FileNotFoundException: Could not load file or assembly 'Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10'. The system cannot find the file specified. 
Sdk.targets(6,5): error :  
Sdk.targets(6,5): error :    at System.Reflection.RuntimeAssembly.InternalLoad(AssemblyName assemblyName, StackCrawlMark& stackMark, AssemblyLoadContext assemblyLoadContext, RuntimeAssembly requestingAssembly, Boolean throwOnFileNotFound) 
Sdk.targets(6,5): error :    at System.Runtime.Loader.AssemblyLoadContext.LoadFromAssemblyName(AssemblyName assemblyName) 
Sdk.targets(6,5): error :    at NetcodePatcher.Tools.Common.PatcherLoadContext.Load(AssemblyName assemblyName) in /home/runner/work/UnityNetcodePatcher/UnityNetcodePatcher/NetcodePatcher.Tools.Common/PatcherLoadContext.cs:line 30 
Sdk.targets(6,5): error :    at System.Runtime.Loader.AssemblyLoadContext.ResolveUsingLoad(AssemblyName assemblyName) 
Sdk.targets(6,5): error :    at System.Runtime.Loader.AssemblyLoadContext.Resolve(IntPtr gchManagedAssemblyLoadContext, AssemblyName assemblyName) 
```

This PR adds code to attempt to manually resolve the assembly from the `PatcherCommonAssemblyDir` before deferring to the `Default` Context.

Additionally it changes the LoggingConfiguarion for the MSBuild Task to also emit Debug messages. These are only shown when MSBuild'ing with verbosity detailed or higher anyway, but filtering them out in the Task leaves them completely inaccessible.