### PR TITLE
Don't run NetcodePatchTask in non-Core MSBuild.

### DIFF
--- a/NetcodePatcher.MSBuild/Sdk/Sdk.targets
+++ b/NetcodePatcher.MSBuild/Sdk/Sdk.targets
@@ -8,6 +8,15 @@
       ReferenceAssemblyPaths="@(ReferencePathWithRefAssemblies)"
       NoOverwrite="$(NetcodePatcherNoOverwrite)"
       DisableParallel="$(NetcodePatcherDisableParallel)"
+      Condition=" '$(MSBuildRuntimeType)' == 'Core' "
+    />
+    <Warning
+      Condition=" '$(MSBuildRuntimeType)' != 'Core' "
+      Code="NCP0001"
+      Text="The NetcodePatcher MSBuild SDK cannot be used in a .NET Framework MSBuild (e.g. Visual Studio).
+            You may ignore this warning if you have set up patching using the command line tool.
+            See the Help Link for details."
+      HelpLink="https://github.com/EvaisaDev/UnityNetcodePatcher#msbuild"
     />
   </Target>
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ Run `netcode-patch --help` for usage information and available options.
 ### MSBuild
 
 > [!IMPORTANT]
-> Since VisualStudio still uses a .NET Framework based MSBuild, some dependendcies requiring .NET Standard 2.1 cannot be loaded into the build host process.
+> Since Visual Studio still uses 'full' MSBuild (which is based on .NET Framework), some dependencies targeting .NET Standard 2.1
+> cannot be loaded into the build host process.
 > Using the CLI tool and post build event is recommended if you are using Visual Studio.
-> You can use both the SDK and CLI tool depending on your build environemnt. See the example under "Usage with VisualStudio" below.
+> You can use both the SDK and CLI tool depending on your build environemnt. See the example under "Usage with Visual Studio" below.
 > *Alternatively you can manually run `dotnet build` from commandline if you do want to use MSBuild.*
 
 NetcodePatcher has an MSBuild plugin that can be applied with minimal configuration.
@@ -104,9 +105,9 @@ to automatically netcode patch the project's output assemblies.
 </details>
 
 <details>
-<summary>Usage with VisualStudio</summary>
+<summary>Usage with Visual Studio</summary>
 
-If you want to support building in both environments (e.g. VisualStudio and `dotnet`) you can use CLI tool for VisualStudio builds, with a `Condition="'$(MSBuildRuntimeType)' != 'Core'"`.
+If you want to support building in both environments (e.g. Visual Studio and `dotnet`) you can use CLI tool for Visual Studio builds, with a `Condition="'$(MSBuildRuntimeType)' != 'Core'"`.
 
 ```xml
 <Project>


### PR DESCRIPTION
This PR changes the SDK settings to instead issue a warning, and adds documentation on how to use both CLI and MSBuild Task to support either environment.

This guards VisualStudio against erroring out not being able to load the MSBuild Task. The net472 variant referenced in `Sdk.tasks` still isn't present in the build (that'd be another, if unnecessary PR), but also isn't loaded if the Task doesn't get called.

That makes the hybrid scenario outlined in the new docs possible.

One more improvement I could think of might be introducing a Property that abstracts away from the `'$(MSBuildRuntimeType)' == 'Core'` condition and hides it from the user. Maybe `$(NetcodePatcherMSBuildUnavailable)`?