### PR TITLE
Dependency cleanup

### DIFF
--- a/NetcodePatcher/NetcodePatcher.csproj
+++ b/NetcodePatcher/NetcodePatcher.csproj
@@ -23,7 +23,6 @@
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.11.5"/>
     <PackageReference Include="Serilog" Version="3.1.1"/>
-    <PackageReference Include="Microsoft.DiaSymReader.Converter" Version="1.1.0-beta2-23252-02"/>
     <Reference Include="Unity.Burst">
       <HintPath>$(ProjectDir)../UnityProject/Library/ScriptAssemblies/Unity.Burst.dll</HintPath>
     </Reference>

--- a/NetcodePatcher/NetcodePatcher.csproj
+++ b/NetcodePatcher/NetcodePatcher.csproj
@@ -22,36 +22,16 @@
   <!-- Runtime dependencies -->
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.11.5"/>
+    <PackageReference Include="System.Reflection.Metadata" Version="8.0.0" />
     <PackageReference Include="Serilog" Version="3.1.1"/>
-    <Reference Include="Unity.Burst">
-      <HintPath>$(ProjectDir)../UnityProject/Library/ScriptAssemblies/Unity.Burst.dll</HintPath>
-    </Reference>
     <Reference Include="Unity.Collections">
       <HintPath>$(ProjectDir)../UnityProject/Library/ScriptAssemblies/Unity.Collections.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.Collections.LowLevel.ILSupport">
-      <HintPath>$(ProjectDir)../UnityProject/Library/ScriptAssemblies/Unity.Collections.LowLevel.ILSupport.dll</HintPath>
     </Reference>
     <Reference Include="Unity.CompilationPipeline.Common">
       <HintPath>$(UnityEditorDir)/Data/Managed/Unity.CompilationPipeline.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Unity.Networking.Transport">
-      <HintPath>$(ProjectDir)../UnityProject/Library/ScriptAssemblies/Unity.Networking.Transport.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.Netcode.Components">
-      <HintPath>$(ProjectDir)../UnityProject/Library/ScriptAssemblies/Unity.Netcode.Components.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine">
-      <HintPath>$(UnityEditorDir)/Data/Managed/UnityEngine/UnityEngine.dll</HintPath>
-    </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>$(UnityEditorDir)/Data/Managed/UnityEngine/UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>$(UnityEditorDir)/Data/Managed/UnityEngine/UnityEngine.IMGUIModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>$(UnityEditorDir)/Data/Managed/UnityEngine/UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
     <ProjectReference Include="$(ProjectDir)../Unity.Netcode.Runtime/Unity.Netcode.Runtime.csproj"/>
   </ItemGroup>

--- a/NetcodePatcher/NetcodePatcher.csproj
+++ b/NetcodePatcher/NetcodePatcher.csproj
@@ -41,9 +41,6 @@
     <Reference Include="Unity.Netcode.Components">
       <HintPath>$(ProjectDir)../UnityProject/Library/ScriptAssemblies/Unity.Netcode.Components.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEditor">
-      <HintPath>$(UnityEditorDir)/Data/Managed/UnityEditor.dll</HintPath>
-    </Reference>
     <Reference Include="UnityEngine">
       <HintPath>$(UnityEditorDir)/Data/Managed/UnityEngine/UnityEngine.dll</HintPath>
     </Reference>

--- a/NetcodePatcher/NetcodePatcher/CodeGen/CompiledAssemblyFromFile.cs
+++ b/NetcodePatcher/NetcodePatcher/CodeGen/CompiledAssemblyFromFile.cs
@@ -3,7 +3,6 @@
 using System;
 using System.IO;
 using System.Reflection.PortableExecutable;
-using Microsoft.DiaSymReader.Tools;
 using NetcodePatcher.Extensions;
 using Serilog;
 using Unity.CompilationPipeline.Common.ILPostProcessing;

--- a/NetcodePatcher/Unity/Netcode/Editor
+++ b/NetcodePatcher/Unity/Netcode/Editor
@@ -1,1 +1,0 @@
-../../../submodules/com.unity.netcode.gameobjects/com.unity.netcode.gameobjects/Editor

--- a/NetcodePatcher/Unity/Netcode/Editor/CodeGen
+++ b/NetcodePatcher/Unity/Netcode/Editor/CodeGen
@@ -1,0 +1,1 @@
+../../../../submodules/com.unity.netcode.gameobjects/com.unity.netcode.gameobjects/Editor/CodeGen

--- a/NuGet.config
+++ b/NuGet.config
@@ -3,6 +3,5 @@
   <packageSources>
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
     <add key="BepInEx" value="https://nuget.bepinex.dev/v3/index.json" />
-    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
     <add key="BepInEx" value="https://nuget.bepinex.dev/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
   </packageSources>

--- a/Unity.Netcode.Runtime/Unity.Netcode.Runtime.csproj
+++ b/Unity.Netcode.Runtime/Unity.Netcode.Runtime.csproj
@@ -6,7 +6,7 @@
     <RootNamespace></RootNamespace>
     <AssemblyName>Unity.Netcode.Runtime</AssemblyName>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <DefineConstants>UNITY_2021_1_OR_NEWER; UNITY_2021_2_OR_NEWER; UNITY_2022_3_OR_NEWER; UNITY_EDITOR; UNITY_INCLUDE_TESTS</DefineConstants>
+    <DefineConstants>UNITY_2021_1_OR_NEWER; UNITY_2021_2_OR_NEWER; UNITY_2022_3_OR_NEWER; UNITY_INCLUDE_TESTS; DEVELOPMENT_BUILD</DefineConstants>
     <Nullable>disable</Nullable>
 
     <IsPackable>false</IsPackable>
@@ -27,30 +27,17 @@
     <Reference Include="Unity.Collections.LowLevel.ILSupport">
       <HintPath>$(ProjectDir)../UnityProject/Library/ScriptAssemblies/Unity.Collections.LowLevel.ILSupport.dll</HintPath>
     </Reference>
-    <Reference Include="Unity.CompilationPipeline.Common">
-      <HintPath>$(UnityEditorDir)/Data/Managed/Unity.CompilationPipeline.Common.dll</HintPath>
-    </Reference>
     <Reference Include="Unity.Networking.Transport">
       <HintPath>$(ProjectDir)../UnityProject/Library/ScriptAssemblies/Unity.Networking.Transport.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Netcode.Components">
       <HintPath>$(ProjectDir)../UnityProject/Library/ScriptAssemblies/Unity.Netcode.Components.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEditor" PrivateAssets="All">
-      <!-- only needed for compile-time InitializeOnLoadMethod marker -->
-      <HintPath>$(UnityEditorDir)/Data/Managed/UnityEditor.dll</HintPath>
-    </Reference>
     <Reference Include="UnityEngine">
       <HintPath>$(UnityEditorDir)/Data/Managed/UnityEngine/UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>$(UnityEditorDir)/Data/Managed/UnityEngine/UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>$(UnityEditorDir)/Data/Managed/UnityEngine/UnityEngine.IMGUIModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>$(UnityEditorDir)/Data/Managed/UnityEngine/UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/Unity.Netcode.Runtime/Unity.Netcode.Runtime.csproj
+++ b/Unity.Netcode.Runtime/Unity.Netcode.Runtime.csproj
@@ -36,7 +36,8 @@
     <Reference Include="Unity.Netcode.Components">
       <HintPath>$(ProjectDir)../UnityProject/Library/ScriptAssemblies/Unity.Netcode.Components.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEditor">
+    <Reference Include="UnityEditor" PrivateAssets="All">
+      <!-- only needed for compile-time InitializeOnLoadMethod marker -->
       <HintPath>$(UnityEditorDir)/Data/Managed/UnityEditor.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">


### PR DESCRIPTION
This PR tries to minimize dependencies needing to be shipped to reduce the size of the nupkg.

I'd like to highlight that:
- `DiaSymReader` isn't needed (anymore), which alleviates the need for the Azure nuget repository
- It can be easily replaced by on of its direct dependencies (`System.Reflection.Metadata`), whose version that was previously used indirectly had been deprecated. Bumped to a current-ish release.
- It should be enough to build the CodeGen Part of the Netcode Editor package, Editor custom components are of little use to us here.

Caveats:
- I'm not sure how well the `DEVELOPMENT_BUILD` define for the Netcode library holds up across versions. It did for all 2-ish that I tested
- I've not actually checked across the entirety of the matrix build locally if "it compiles" implies "it works". 😅

